### PR TITLE
Downgrade support library

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -62,7 +62,7 @@ task checkstyle(type: Checkstyle) {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:appcompat-v7:27.1.0'
     implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.10.0'
 }
 


### PR DESCRIPTION
Support library has been downgraded from 27.1.1 to 27.1.0 because
it had clashing dependencies with the sub-sampling scale image
library. The IDE was warning about possible problems at runtime if
using different versions of the support library.

### :tophat: What is the goal?

The goal is to downgrade the support library version in order to avoid problems at runtime.

### How is it being implemented?

By decreasing the minor version of the support library.

### QA Risks

There's a small change that view pager does not work properly.

### How can it be tested?

By running the test suite and/or testing with a custom pdf file.

### GIF

![something](https://media.giphy.com/media/WgSMrU1v8RfQVxJTkj/giphy.gif)
