### PR TITLE
Propagate the exception thrown by PdfRenderer

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -37,6 +37,7 @@ android {
         targetSdkVersion 27
         versionCode 7
         versionName "1.0.0"
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -64,6 +65,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.0'
     implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.10.0'
+
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }
 
 // Bintray installing and uploading scripts

--- a/library/src/androidTest/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapterTest.kt
+++ b/library/src/androidTest/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapterTest.kt
@@ -2,12 +2,12 @@ package es.voghdev.pdfviewpager.library.adapter
 
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
+import es.voghdev.pdfviewpager.library.exception.CorruptPdfException
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
-import java.io.IOException
 
 @RunWith(AndroidJUnit4::class)
 class PDFPagerAdapterTest {
@@ -31,7 +31,7 @@ class PDFPagerAdapterTest {
         }
     }
 
-    @Test(expected = IOException::class)
+    @Test(expected = CorruptPdfException::class)
     fun shouldThrowExceptionIfPdfIsNotValid() {
         PDFPagerAdapter(context, tempFile.absolutePath)
     }

--- a/library/src/androidTest/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapterTest.kt
+++ b/library/src/androidTest/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapterTest.kt
@@ -1,0 +1,38 @@
+package es.voghdev.pdfviewpager.library.adapter
+
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class PDFPagerAdapterTest {
+
+    private val context get() = InstrumentationRegistry.getContext()
+    private val tempFile by lazy { File(context.cacheDir, "tempFile.pdf") }
+
+    @Before
+    fun setUp() {
+        with(tempFile) {
+            if (exists()) delete()
+            createNewFile()
+            writeText("this text does not represent a pdf file")
+        }
+    }
+
+    @After
+    fun tearDown() {
+        with(tempFile) {
+            if (exists()) delete()
+        }
+    }
+
+    @Test(expected = IOException::class)
+    fun shouldThrowExceptionIfPdfIsNotValid() {
+        PDFPagerAdapter(context, tempFile.absolutePath)
+    }
+}

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java
@@ -21,28 +21,30 @@ import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 
+import java.io.IOException;
+
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
 
 public class PDFViewPager extends ViewPager {
     protected Context context;
 
-    public PDFViewPager(Context context, String pdfPath) {
+    public PDFViewPager(Context context, String pdfPath) throws IOException {
         super(context);
         this.context = context;
         init(pdfPath);
     }
 
-    public PDFViewPager(Context context, AttributeSet attrs) {
+    public PDFViewPager(Context context, AttributeSet attrs) throws IOException {
         super(context, attrs);
         this.context = context;
         init(attrs);
     }
 
-    protected void init(String pdfPath) {
+    protected void init(String pdfPath) throws IOException {
         initAdapter(context, pdfPath);
     }
 
-    protected void init(AttributeSet attrs) {
+    protected void init(AttributeSet attrs) throws IOException {
         if (isInEditMode()) {
             setBackgroundResource(R.drawable.flaticon_pdf_dummy);
             return;
@@ -62,7 +64,7 @@ public class PDFViewPager extends ViewPager {
         }
     }
 
-    protected void initAdapter(Context context, String pdfPath) {
+    protected void initAdapter(Context context, String pdfPath) throws IOException {
         setAdapter(new PDFPagerAdapter.Builder(context)
                 .setPdfPath(pdfPath)
                 .setOffScreenSize(getOffscreenPageLimit())

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java
@@ -21,30 +21,29 @@ import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 
-import java.io.IOException;
-
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
+import es.voghdev.pdfviewpager.library.exception.CorruptPdfException;
 
 public class PDFViewPager extends ViewPager {
     protected Context context;
 
-    public PDFViewPager(Context context, String pdfPath) throws IOException {
+    public PDFViewPager(Context context, String pdfPath) throws CorruptPdfException {
         super(context);
         this.context = context;
         init(pdfPath);
     }
 
-    public PDFViewPager(Context context, AttributeSet attrs) throws IOException {
+    public PDFViewPager(Context context, AttributeSet attrs) throws CorruptPdfException {
         super(context, attrs);
         this.context = context;
         init(attrs);
     }
 
-    protected void init(String pdfPath) throws IOException {
+    protected void init(String pdfPath) throws CorruptPdfException {
         initAdapter(context, pdfPath);
     }
 
-    protected void init(AttributeSet attrs) throws IOException {
+    protected void init(AttributeSet attrs) throws CorruptPdfException {
         if (isInEditMode()) {
             setBackgroundResource(R.drawable.flaticon_pdf_dummy);
             return;
@@ -64,7 +63,7 @@ public class PDFViewPager extends ViewPager {
         }
     }
 
-    protected void initAdapter(Context context, String pdfPath) throws IOException {
+    protected void initAdapter(Context context, String pdfPath) throws CorruptPdfException {
         setAdapter(new PDFPagerAdapter.Builder(context)
                 .setPdfPath(pdfPath)
                 .setOffScreenSize(getOffscreenPageLimit())

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPagerZoom.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPagerZoom.java
@@ -20,19 +20,21 @@ import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 
+import java.io.IOException;
+
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
 import es.voghdev.pdfviewpager.library.adapter.PdfScale;
 
 public class PDFViewPagerZoom extends PDFViewPager {
-    public PDFViewPagerZoom(Context context, String pdfPath) {
+    public PDFViewPagerZoom(Context context, String pdfPath) throws IOException {
         super(context, pdfPath);
     }
 
-    public PDFViewPagerZoom(Context context, AttributeSet attrs) {
+    public PDFViewPagerZoom(Context context, AttributeSet attrs) throws IOException {
         super(context, attrs);
     }
 
-    protected void initAdapter(Context context, String pdfPath) {
+    protected void initAdapter(Context context, String pdfPath) throws IOException {
         setAdapter(new PDFPagerAdapter.Builder(context)
                 .setPdfPath(pdfPath)
                 .setOffScreenSize(getOffscreenPageLimit())
@@ -40,7 +42,7 @@ public class PDFViewPagerZoom extends PDFViewPager {
         );
     }
 
-    protected void init(AttributeSet attrs) {
+    protected void init(AttributeSet attrs) throws IOException {
         if (isInEditMode()) {
             setBackgroundResource(R.drawable.flaticon_pdf_dummy);
             return;

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPagerZoom.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPagerZoom.java
@@ -20,21 +20,20 @@ import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 
-import java.io.IOException;
-
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
 import es.voghdev.pdfviewpager.library.adapter.PdfScale;
+import es.voghdev.pdfviewpager.library.exception.CorruptPdfException;
 
 public class PDFViewPagerZoom extends PDFViewPager {
-    public PDFViewPagerZoom(Context context, String pdfPath) throws IOException {
+    public PDFViewPagerZoom(Context context, String pdfPath) throws CorruptPdfException {
         super(context, pdfPath);
     }
 
-    public PDFViewPagerZoom(Context context, AttributeSet attrs) throws IOException {
+    public PDFViewPagerZoom(Context context, AttributeSet attrs) throws CorruptPdfException {
         super(context, attrs);
     }
 
-    protected void initAdapter(Context context, String pdfPath) throws IOException {
+    protected void initAdapter(Context context, String pdfPath) throws CorruptPdfException {
         setAdapter(new PDFPagerAdapter.Builder(context)
                 .setPdfPath(pdfPath)
                 .setOffScreenSize(getOffscreenPageLimit())
@@ -42,7 +41,7 @@ public class PDFViewPagerZoom extends PDFViewPager {
         );
     }
 
-    protected void init(AttributeSet attrs) throws IOException {
+    protected void init(AttributeSet attrs) throws CorruptPdfException {
         if (isInEditMode()) {
             setBackgroundResource(R.drawable.flaticon_pdf_dummy);
             return;

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.net.URI;
 
 import es.voghdev.pdfviewpager.library.R;
+import es.voghdev.pdfviewpager.library.exception.CorruptPdfException;
 
 public class BasePDFPagerAdapter extends PagerAdapter {
     protected static final int FIRST_PAGE = 0;
@@ -48,7 +49,7 @@ public class BasePDFPagerAdapter extends PagerAdapter {
     protected float renderQuality;
     protected int offScreenSize;
 
-    public BasePDFPagerAdapter(Context context, String pdfPath) throws IOException {
+    public BasePDFPagerAdapter(Context context, String pdfPath) throws CorruptPdfException {
         this.pdfPath = pdfPath;
         this.context = context;
         this.renderQuality = DEFAULT_QUALITY;
@@ -60,7 +61,7 @@ public class BasePDFPagerAdapter extends PagerAdapter {
     /**
      * This constructor was added for those who want to customize ViewPager's offScreenSize attr
      */
-    public BasePDFPagerAdapter(Context context, String pdfPath, int offScreenSize) throws IOException {
+    public BasePDFPagerAdapter(Context context, String pdfPath, int offScreenSize) throws CorruptPdfException {
         this.pdfPath = pdfPath;
         this.context = context;
         this.renderQuality = DEFAULT_QUALITY;
@@ -70,8 +71,13 @@ public class BasePDFPagerAdapter extends PagerAdapter {
     }
 
     @SuppressWarnings("NewApi")
-    protected void init() throws IOException {
-        renderer = new PdfRenderer(getSeekableFileDescriptor(pdfPath));
+    protected void init() throws CorruptPdfException {
+        try {
+            renderer = new PdfRenderer(getSeekableFileDescriptor(pdfPath));
+        } catch (IOException e) {
+            throw new CorruptPdfException(e.getMessage(), e.getCause());
+        }
+
         inflater = (LayoutInflater) context.getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
         PdfRendererParams params = extractPdfParamsFromFirstPage(renderer, renderQuality);
         bitmapContainer = new SimpleBitmapPool(params);

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
@@ -48,7 +48,7 @@ public class BasePDFPagerAdapter extends PagerAdapter {
     protected float renderQuality;
     protected int offScreenSize;
 
-    public BasePDFPagerAdapter(Context context, String pdfPath) {
+    public BasePDFPagerAdapter(Context context, String pdfPath) throws IOException {
         this.pdfPath = pdfPath;
         this.context = context;
         this.renderQuality = DEFAULT_QUALITY;
@@ -60,7 +60,7 @@ public class BasePDFPagerAdapter extends PagerAdapter {
     /**
      * This constructor was added for those who want to customize ViewPager's offScreenSize attr
      */
-    public BasePDFPagerAdapter(Context context, String pdfPath, int offScreenSize) {
+    public BasePDFPagerAdapter(Context context, String pdfPath, int offScreenSize) throws IOException {
         this.pdfPath = pdfPath;
         this.context = context;
         this.renderQuality = DEFAULT_QUALITY;
@@ -70,15 +70,11 @@ public class BasePDFPagerAdapter extends PagerAdapter {
     }
 
     @SuppressWarnings("NewApi")
-    protected void init() {
-        try {
-            renderer = new PdfRenderer(getSeekableFileDescriptor(pdfPath));
-            inflater = (LayoutInflater) context.getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
-            PdfRendererParams params = extractPdfParamsFromFirstPage(renderer, renderQuality);
-            bitmapContainer = new SimpleBitmapPool(params);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+    protected void init() throws IOException {
+        renderer = new PdfRenderer(getSeekableFileDescriptor(pdfPath));
+        inflater = (LayoutInflater) context.getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
+        PdfRendererParams params = extractPdfParamsFromFirstPage(renderer, renderQuality);
+        bitmapContainer = new SimpleBitmapPool(params);
     }
 
     @SuppressWarnings("NewApi")

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapter.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapter.java
@@ -18,12 +18,14 @@ package es.voghdev.pdfviewpager.library.adapter;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.pdf.PdfRenderer;
+import android.support.v4.view.ViewPager;
 import android.view.View;
 import android.view.ViewGroup;
-import android.support.v4.view.ViewPager;
 
 import com.davemorrissey.labs.subscaleview.ImageSource;
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
+
+import java.io.IOException;
 
 import es.voghdev.pdfviewpager.library.R;
 import es.voghdev.pdfviewpager.library.util.EmptyClickListener;
@@ -35,7 +37,7 @@ public class PDFPagerAdapter extends BasePDFPagerAdapter {
     PdfScale scale = new PdfScale();
     View.OnClickListener pageClickListener = new EmptyClickListener();
 
-    public PDFPagerAdapter(Context context, String pdfPath) {
+    public PDFPagerAdapter(Context context, String pdfPath) throws IOException {
         super(context, pdfPath);
     }
 
@@ -123,7 +125,7 @@ public class PDFPagerAdapter extends BasePDFPagerAdapter {
             return this;
         }
 
-        public PDFPagerAdapter create() {
+        public PDFPagerAdapter create() throws IOException {
             PDFPagerAdapter adapter = new PDFPagerAdapter(context, pdfPath);
             adapter.scale.setScale(scale);
             adapter.scale.setCenterX(centerX);

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapter.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapter.java
@@ -25,9 +25,8 @@ import android.view.ViewGroup;
 import com.davemorrissey.labs.subscaleview.ImageSource;
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
 
-import java.io.IOException;
-
 import es.voghdev.pdfviewpager.library.R;
+import es.voghdev.pdfviewpager.library.exception.CorruptPdfException;
 import es.voghdev.pdfviewpager.library.util.EmptyClickListener;
 
 public class PDFPagerAdapter extends BasePDFPagerAdapter {
@@ -37,7 +36,7 @@ public class PDFPagerAdapter extends BasePDFPagerAdapter {
     PdfScale scale = new PdfScale();
     View.OnClickListener pageClickListener = new EmptyClickListener();
 
-    public PDFPagerAdapter(Context context, String pdfPath) throws IOException {
+    public PDFPagerAdapter(Context context, String pdfPath) throws CorruptPdfException {
         super(context, pdfPath);
     }
 
@@ -125,7 +124,7 @@ public class PDFPagerAdapter extends BasePDFPagerAdapter {
             return this;
         }
 
-        public PDFPagerAdapter create() throws IOException {
+        public PDFPagerAdapter create() throws CorruptPdfException {
             PDFPagerAdapter adapter = new PDFPagerAdapter(context, pdfPath);
             adapter.scale.setScale(scale);
             adapter.scale.setCenterX(centerX);

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/exception/CorruptPdfException.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/exception/CorruptPdfException.java
@@ -1,0 +1,7 @@
+package es.voghdev.pdfviewpager.library.exception;
+
+public class CorruptPdfException extends Exception {
+    public CorruptPdfException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sample/src/main/java/es/voghdev/pdfviewpager/AssetOnSDActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/AssetOnSDActivity.java
@@ -23,12 +23,12 @@ import android.os.Handler;
 import android.widget.Toast;
 
 import java.io.File;
-import java.io.IOException;
 
 import es.voghdev.pdfviewpager.library.PDFViewPager;
 import es.voghdev.pdfviewpager.library.adapter.BasePDFPagerAdapter;
 import es.voghdev.pdfviewpager.library.asset.CopyAsset;
 import es.voghdev.pdfviewpager.library.asset.CopyAssetThreadImpl;
+import es.voghdev.pdfviewpager.library.exception.CorruptPdfException;
 
 public class AssetOnSDActivity extends BaseSampleActivity {
     final String[] sampleAssets = {"adobe.pdf", "sample.pdf"};
@@ -54,7 +54,7 @@ public class AssetOnSDActivity extends BaseSampleActivity {
                 try {
                     pdfViewPager = new PDFViewPager(context, getPdfPathOnSDCard());
                     setContentView(pdfViewPager);
-                } catch (IOException e) {
+                } catch (CorruptPdfException e) {
                     failure(e);
                 }
             }

--- a/sample/src/main/java/es/voghdev/pdfviewpager/AssetOnSDActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/AssetOnSDActivity.java
@@ -23,6 +23,7 @@ import android.os.Handler;
 import android.widget.Toast;
 
 import java.io.File;
+import java.io.IOException;
 
 import es.voghdev.pdfviewpager.library.PDFViewPager;
 import es.voghdev.pdfviewpager.library.adapter.BasePDFPagerAdapter;
@@ -50,8 +51,12 @@ public class AssetOnSDActivity extends BaseSampleActivity {
         CopyAsset copyAsset = new CopyAssetThreadImpl(getApplicationContext(), new Handler(), new CopyAsset.Listener() {
             @Override
             public void success(String assetName, String destinationPath) {
-                pdfViewPager = new PDFViewPager(context, getPdfPathOnSDCard());
-                setContentView(pdfViewPager);
+                try {
+                    pdfViewPager = new PDFViewPager(context, getPdfPathOnSDCard());
+                    setContentView(pdfViewPager);
+                } catch (IOException e) {
+                    failure(e);
+                }
             }
 
             @Override

--- a/sample/src/main/java/es/voghdev/pdfviewpager/MainActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/MainActivity.java
@@ -20,6 +20,8 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
 
+import java.io.IOException;
+
 import es.voghdev.pdfviewpager.library.PDFViewPager;
 import es.voghdev.pdfviewpager.library.adapter.BasePDFPagerAdapter;
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
@@ -36,8 +38,12 @@ public class MainActivity extends BaseSampleActivity {
 
         pdfViewPager = (PDFViewPager) findViewById(R.id.pdfViewPager);
 
-        adapter = new PDFPagerAdapter(this, "sample.pdf");
-        pdfViewPager.setAdapter(adapter);
+        try {
+            adapter = new PDFPagerAdapter(this, "sample.pdf");
+            pdfViewPager.setAdapter(adapter);
+        } catch (IOException exception) {
+            exception.printStackTrace();
+        }
     }
 
     @Override

--- a/sample/src/main/java/es/voghdev/pdfviewpager/MainActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/MainActivity.java
@@ -20,11 +20,10 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
 
-import java.io.IOException;
-
 import es.voghdev.pdfviewpager.library.PDFViewPager;
 import es.voghdev.pdfviewpager.library.adapter.BasePDFPagerAdapter;
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
+import es.voghdev.pdfviewpager.library.exception.CorruptPdfException;
 
 public class MainActivity extends BaseSampleActivity {
     PDFViewPager pdfViewPager;
@@ -41,7 +40,7 @@ public class MainActivity extends BaseSampleActivity {
         try {
             adapter = new PDFPagerAdapter(this, "sample.pdf");
             pdfViewPager.setAdapter(adapter);
-        } catch (IOException exception) {
+        } catch (CorruptPdfException exception) {
             exception.printStackTrace();
         }
     }

--- a/sample/src/main/java/es/voghdev/pdfviewpager/PDFWithScaleActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/PDFWithScaleActivity.java
@@ -23,6 +23,8 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.widget.Toast;
 
+import java.io.IOException;
+
 import es.voghdev.pdfviewpager.library.PDFViewPager;
 import es.voghdev.pdfviewpager.library.adapter.BasePDFPagerAdapter;
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
@@ -36,20 +38,25 @@ public class PDFWithScaleActivity extends BaseSampleActivity {
         super.onCreate(savedInstanceState);
 
         setTitle(R.string.menu_sample9_txt);
-        pdfViewPager = new PDFViewPager(this, "moby.pdf");
-        setContentView(pdfViewPager);
-        pdfViewPager.setAdapter(new PDFPagerAdapter.Builder(this)
-                .setPdfPath("moby.pdf")
-                .setScale(getPdfScale())
-                .setOnPageClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        pdfViewPager.setVisibility(View.GONE);
-                        Toast.makeText(PDFWithScaleActivity.this, R.string.page_was_clicked, Toast.LENGTH_LONG).show();
-                    }
-                })
-                .create()
-        );
+
+        try {
+            pdfViewPager = new PDFViewPager(this, "moby.pdf");
+            setContentView(pdfViewPager);
+            pdfViewPager.setAdapter(new PDFPagerAdapter.Builder(this)
+                    .setPdfPath("moby.pdf")
+                    .setScale(getPdfScale())
+                    .setOnPageClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            pdfViewPager.setVisibility(View.GONE);
+                            Toast.makeText(PDFWithScaleActivity.this, R.string.page_was_clicked, Toast.LENGTH_LONG).show();
+                        }
+                    })
+                    .create()
+            );
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     private PdfScale getPdfScale() {

--- a/sample/src/main/java/es/voghdev/pdfviewpager/PDFWithScaleActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/PDFWithScaleActivity.java
@@ -23,12 +23,11 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.widget.Toast;
 
-import java.io.IOException;
-
 import es.voghdev.pdfviewpager.library.PDFViewPager;
 import es.voghdev.pdfviewpager.library.adapter.BasePDFPagerAdapter;
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
 import es.voghdev.pdfviewpager.library.adapter.PdfScale;
+import es.voghdev.pdfviewpager.library.exception.CorruptPdfException;
 
 public class PDFWithScaleActivity extends BaseSampleActivity {
     PDFViewPager pdfViewPager;
@@ -54,7 +53,7 @@ public class PDFWithScaleActivity extends BaseSampleActivity {
                     })
                     .create()
             );
-        } catch (IOException e) {
+        } catch (CorruptPdfException e) {
             e.printStackTrace();
         }
     }

--- a/sample/src/main/java/es/voghdev/pdfviewpager/RemotePDFActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/RemotePDFActivity.java
@@ -23,6 +23,8 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
+import java.io.IOException;
+
 import es.voghdev.pdfviewpager.library.RemotePDFViewPager;
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
 import es.voghdev.pdfviewpager.library.remote.DownloadFile;
@@ -99,10 +101,14 @@ public class RemotePDFActivity extends BaseSampleActivity implements DownloadFil
 
     @Override
     public void onSuccess(String url, String destinationPath) {
-        adapter = new PDFPagerAdapter(this, FileUtil.extractFileNameFromURL(url));
-        remotePDFViewPager.setAdapter(adapter);
-        updateLayout();
-        showDownloadButton();
+        try {
+            adapter = new PDFPagerAdapter(this, FileUtil.extractFileNameFromURL(url));
+            remotePDFViewPager.setAdapter(adapter);
+            updateLayout();
+            showDownloadButton();
+        } catch (IOException exception) {
+            onFailure(exception);
+        }
     }
 
     @Override

--- a/sample/src/main/java/es/voghdev/pdfviewpager/RemotePDFActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/RemotePDFActivity.java
@@ -23,10 +23,9 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
-import java.io.IOException;
-
 import es.voghdev.pdfviewpager.library.RemotePDFViewPager;
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
+import es.voghdev.pdfviewpager.library.exception.CorruptPdfException;
 import es.voghdev.pdfviewpager.library.remote.DownloadFile;
 import es.voghdev.pdfviewpager.library.util.FileUtil;
 
@@ -106,7 +105,7 @@ public class RemotePDFActivity extends BaseSampleActivity implements DownloadFil
             remotePDFViewPager.setAdapter(adapter);
             updateLayout();
             showDownloadButton();
-        } catch (IOException exception) {
+        } catch (CorruptPdfException exception) {
             onFailure(exception);
         }
     }


### PR DESCRIPTION
When PdfRenderer throws an exception it is captured and hidden. This
is a problem because when we are using this library we cannot handle
that error case properly.

Now the exception is propagated and thrown outside the library. This
commit introduces breaking changes.

### :tophat: What is the goal?

The goal is to propagate the exception thrown my the native class `PdfRenderer` so it can be handled outside the library.

### How is it being implemented?

By removing the `try/catch` and adding the corresponding `throws` directives. Also, in the sample app, which is not critical actually, some `try/catch` methods have been added.

### QA Risks

This is a breaking change in the library. Fortunately, it's our first use of it, so there should be no problem.

### How can it be tested?

By executing the new test for that purpose.

### GIF

![something](https://media.giphy.com/media/X92pmIty2ZJp6/giphy.gif)
